### PR TITLE
Add missing mlflow-faculty dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,9 @@ setup(
     py_modules=["faculty_models"],
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=["faculty>=0.25.4", "mlflow==1.2.0"],
+    install_requires=[
+        "faculty>=0.25.4",
+        "mlflow==1.2.0",
+        "mlflow-faculty>=0.4.3",
+    ],
 )


### PR DESCRIPTION
Required to be able to handle the faculty artifact scheme, otherwise
would end up throwing an error like this:
```
mlflow.exceptions.MlflowException: Could not find a registered artifact repository for: faculty-datasets:123/.mlflow-artifacts/3/abc/xyz. Currently registered schemes are: ['', 'file', 's3', 'gs', 'wasbs', 'ftp', 'sftp', 'dbfs', 'hdfs', 'runs']
```

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>