### PR TITLE
Add more Python versions to test: 3.7/3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
       env: TOXENV=py27
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
     - name: Check black formatting
       python: 3.6
       env: TOXENV=black

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, flake8, black, license
+envlist = py27, py34, py35, py36, py37, py38, flake8, black, license
 
 [testenv]
 sitepackages = False


### PR DESCRIPTION
Even though the Platform uses a specific Python, there are
newer versions out there, so users of this library are not expected
to use the same Python as the platform. Cover more versions to
potentially catch issues with other Python versions earlier.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>